### PR TITLE
Add extension registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 1.1.0
+
+* Add extension registration.
+
 ## Version 1.0.2
 
 * POST purge link to avoid confirmation

--- a/Purge.php
+++ b/Purge.php
@@ -5,7 +5,7 @@
  * @author Ævar Arnfjörð Bjarmason <avarab@gmail.com>
  * @copyright Copyright © 2005, Ævar Arnfjörð Bjarmason
  * @license http://www.gnu.org/copyleft/gpl.html GNU General Public License 2.0 or later
- * 
+ *
  *  This is a fork of the original  see https://www.mediawiki.org/wiki/Extension:Purge
  *  Updated by Tom Hutchison to use proper i18n json files
  *  Changed extension hook to SkinTemplateNavigation
@@ -18,45 +18,8 @@ if( !defined( 'MEDIAWIKI' ) ) {
 	die( 1 );
 }
 
-$wgExtensionCredits['other'][] = array(
-    'path' => __FILE__,
-    'name' => 'Purge',
-    'author' => 'Tom Hutchison', 
-    'url' => 'https://www.mediawiki.org/wiki/Extension:Purge',
-    'descriptionmsg' => 'descriptionmsg',
-    'version'  => '1.0.2',
-    'license-name' => "GPL-2.0+",
-);
-
-$wgMessagesDirs['Purge'] = __DIR__ . '/i18n';
-$wgExtensionMessagesFiles['Purge'] = __DIR__ . '/Purge.i18n.php';
-
-$wgHooks['SkinTemplateNavigation'][] = 'PurgeActionExtension::contentHook';
-
-$wgResourceModules['ext.purge'] = [
-	'localBasePath' => __DIR__,
-	'remoteExtPath' => 'Purge',
-	'scripts' => [ 'resources/ext.purge.js' ],
-	'messages' => [ 'purge-failed', ],
-];
-
-class PurgeActionExtension{
-	public static function contentHook( $skin, array &$content_actions ) {
-		global $wgRequest, $wgUser;
-		// Use getRelevantTitle if present so that this will work on some special pages
-		$title = method_exists( $skin, 'getRelevantTitle' ) ?
-			$skin->getRelevantTitle() : $skin->getTitle();
-		if ( $title->getNamespace() !== NS_SPECIAL && $wgUser->isAllowed( 'purge' ) ) {
-			$skin->getOutput()->addModules( 'ext.purge' );
-			$action = $wgRequest->getText( 'action' );
-
-			$content_actions['actions']['purge'] = array(
-				'class' => $action === 'purge' ? 'selected' : false,
-				'text' => wfMessage( 'purge' )->text(),
-				'href' => $title->getLocalUrl( 'action=purge' )
-			);
-		}
-
-		return true;
-	}
+if ( function_exists( 'wfLoadExtension' ) ) {
+	wfLoadExtension( 'Purge' );
+} else {
+	die( 'This version of the Purge extension requires MediaWiki 1.25+' );
 }

--- a/README.md
+++ b/README.md
@@ -1,15 +1,3 @@
-## MediaWiki Purge Extension
+# MediaWiki Purge Extension
 
-Adds a Purge `&action=purge` link tab of regular articles to your MediaWiki Skin allowing quick purging of page caches.
-
-### Installation
-
-Download and upload the zip file to `/extensions` and extract. Rename directory folder `/Purge-#-#-#` to `/Purge` and add the following to `LocalSettings.php` to enable this extension.
-
-`require_once "$IP/extensions/Purge/Purge.php";`
-
-Control the ability by user group to purge content. eg `['*']` would allow anyone, `['user']` allows only users or `['sysop']` would only allow sysops.
-
-`$wgGroupPermissions['{a user group}']['purge'] = true; # delete the cache of a page`
-
-See https://www.mediawiki.org/wiki/Manual:Purge for more information about purging a page's cache.
+For more information, see [mediawiki.org/wiki/Extension:Purge](https://www.mediawiki.org/wiki/Extension:Purge).

--- a/extension.json
+++ b/extension.json
@@ -1,0 +1,39 @@
+{
+	"name": "Purge",
+	"version": "1.0.2",
+	"author": [
+		"[https://www.mediawiki.org/wiki/User:Ævar_Arnfjörð_Bjarmason Ævar Arnfjörð Bjarmason]",
+		"[https://www.mediawiki.org/wiki/User:Hutchy68 Tom Hutchison]",
+		"[https://www.mediawiki.org/wiki/User:Samwilson Sam Wilson]"
+	],
+	"url": "https://www.mediawiki.org/wiki/Extension:Purge",
+	"descriptionmsg": "purge-descriptionmsg",
+	"license-name": "GPL-2.0+",
+	"type": "other",
+	"MessagesDirs": {
+		"Purge": [
+			"i18n"
+		]
+	},
+	"ResourceModules": {
+		"ext.purge": {
+			"scripts": [
+				"resources/ext.purge.js"
+			],
+			"messages": [
+				"purge-failed"
+			]
+		}
+	},
+	"ResourceFileModulePaths": {
+		"localBasePath": "",
+		"remoteExtPath": "Purge"
+	},
+	"AutoloadClasses": {
+		"MediaWiki\\Extension\\Purge\\Hooks": "includes/Hooks.php"
+	},
+	"Hooks": {
+		"SkinTemplateNavigation": "MediaWiki\\Extension\\Purge\\Hooks::onSkinTemplateNavigation"
+	},
+	"manifest_version": 2
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -5,6 +5,6 @@
 		]
 	},
 	"purge": "Purge",
-	"descriptionmsg": "Adds a purge tab on all normal pages allowing for quick purging of the cache",
+	"purge-descriptionmsg": "Adds a purge tab on all normal pages allowing for quick purging of the cache",
 	"purge-failed": "Purge failed"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -9,6 +9,6 @@
 		]
 	},
 	"purge": "Displayed as a label in the action menu.\n{{Identical|Purge}}",
-	"descriptionmsg": "{{desc|name=Purge|url=https://www.mediawiki.org/wiki/Extension:Purge}}\n\"purge\" refers to {{msg-mw|purge}}.",
+	"purge-descriptionmsg": "{{desc|name=Purge|url=https://www.mediawiki.org/wiki/Extension:Purge}}\n\"purge\" refers to {{msg-mw|purge}}.",
 	"purge-failed": "Displayed when the POST request to purge did not succeed."
 }

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace MediaWiki\Extension\Purge;
+
+use SkinTemplate;
+
+class Hooks {
+
+	/**
+	 * @link https://www.mediawiki.org/wiki/Manual:Hooks/SkinTemplateNavigation
+	 * @param SkinTemplate $sktemplate The skin template object.
+	 * @param array $links The existing structured navigation links.
+	 * @return bool
+	 */
+	public static function onSkinTemplateNavigation( SkinTemplate &$sktemplate, array &$links ) { 
+		// Use getRelevantTitle if present so that this will work on some special pages
+		$title = method_exists( $sktemplate, 'getRelevantTitle' )
+			? $sktemplate->getRelevantTitle()
+			: $sktemplate->getTitle();
+		if ( $title->getNamespace() !== NS_SPECIAL && $sktemplate->getUser()->isAllowed( 'purge' ) ) {
+			$sktemplate->getOutput()->addModules( 'ext.purge' );
+			$action = $sktemplate->getRequest()->getText( 'action' );
+
+			$links['actions']['purge'] = [
+				'class' => $action === 'purge' ? 'selected' : false,
+				'text' => wfMessage( 'purge' )->text(),
+				'href' => $title->getLocalUrl( 'action=purge' )
+			];
+		}
+
+		return true;
+	}
+}


### PR DESCRIPTION
This change:
* adds extension.json (with backwards compatible loading from
  Purge.php);
* fixes a possible conflict with a message name;
* removes installation instructions etc. from README and points
  instead to the mediawiki.org page; and
* removes the global variables from the navigation links hook.

Refs: #3 