### PR TITLE
Add 'g' accesskey for the purge action

### DIFF
--- a/Purge.php
+++ b/Purge.php
@@ -53,6 +53,7 @@ class PurgeActionExtension{
 			$content_actions['actions']['purge'] = array(
 				'class' => $action === 'purge' ? 'selected' : false,
 				'text' => wfMessage( 'purge' )->text(),
+				'accesskey' => wfMessage( 'purge-accesskey' ),
 				'href' => $title->getLocalUrl( 'action=purge' )
 			);
 		}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6,5 +6,6 @@
 	},
 	"purge": "Purge",
 	"descriptionmsg": "Adds a purge tab on all normal pages allowing for quick purging of the cache",
-	"purge-failed": "Purge failed"
+	"purge-failed": "Purge failed",
+	"purge-accesskey": "g"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -10,5 +10,6 @@
 	},
 	"purge": "Displayed as a label in the action menu.\n{{Identical|Purge}}",
 	"descriptionmsg": "{{desc|name=Purge|url=https://www.mediawiki.org/wiki/Extension:Purge}}\n\"purge\" refers to {{msg-mw|purge}}.",
-	"purge-failed": "Displayed when the POST request to purge did not succeed."
+	"purge-failed": "Displayed when the POST request to purge did not succeed.",
+	"purge-accesskey": "{{doc-accesskey}}"
 }


### PR DESCRIPTION
According to https://www.mediawiki.org/wiki/Manual:Interface/Access_keys the `g` access key is not currently used (at least in core; I'm not sure if there's a list anywhere of extensions' access keys).