### PR TITLE
Fix to JS to Purge in place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 3.0.0
+
+* Bump major version as it requires MW 1.35+
+
 ## Version 2.0.0
 
 * Add extension registration.

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "Purge",
-	"version": "2.0.0",
+	"version": "3.0.0",
 	"author": [
 		"[https://www.mediawiki.org/wiki/User:Ævar_Arnfjörð_Bjarmason Ævar Arnfjörð Bjarmason]",
 		"[https://www.mediawiki.org/wiki/User:Hutchy68 Tom Hutchison]",
@@ -11,7 +11,7 @@
 	"license-name": "GPL-2.0+",
 	"type": "other",
 	"requires": {
-		"MediaWiki": ">= 1.31.0"
+		"MediaWiki": ">= 1.35.0"
 	},
 	"MessagesDirs": {
 		"Purge": [

--- a/resources/ext.purge.js
+++ b/resources/ext.purge.js
@@ -1,5 +1,5 @@
 
-mw.loader.using( [ 'mediawiki.api', 'mediawiki.notify' ] ).then( function () {
+mw.loader.using( [ 'mediawiki.api' ] ).then( function () {
 
 	$( "#ca-purge a" ).on( 'click', function ( e ) {
 		var postArgs = { action: 'purge', titles: mw.config.get( 'wgPageName' ) };


### PR DESCRIPTION
`mw-notify()` is now available by default.

Per [Breaking changes](https://www.mediawiki.org/wiki/Release_notes/1.35#Breaking_changes_in_1.35) for 1.35 release
>The mediawiki.notify module was removed. The mw.notify() shortcut is now available by default, without any dependency.