### PR TITLE
Use document.querySelector instead of jquery

### DIFF
--- a/resources/ext.purge.js
+++ b/resources/ext.purge.js
@@ -1,7 +1,7 @@
 
 mw.loader.using( [ 'mediawiki.api', 'mediawiki.notify' ] ).then( function () {
 
-	$( "#ca-purge a" ).on( 'click', function ( e ) {
+	document.querySelector( '#ca-purge a' ).addEventListener( 'click', function ( e ) {
 		var postArgs = { action: 'purge', titles: mw.config.get( 'wgPageName' ) };
 		new mw.Api().post( postArgs ).then( function () {
 			location.reload();


### PR DESCRIPTION
For some reason, preventDefault() does not work for `<a>` element for me. Even if it's not true, removing jquery will improve the performance.